### PR TITLE
Make Wifi setup more resilient

### DIFF
--- a/botvac-wifi.ino
+++ b/botvac-wifi.ino
@@ -23,9 +23,12 @@
 
 #define AP_SSID "neato"
 
+#define FIRMWARE = "1.7"
+
+#define MAX_BUFFER 8192
+
 String readString;
 String incomingErr;
-String firmware = "1.7";
 String batteryInfo;
 String lidarInfo;
 String serialNumber = "Empty";
@@ -34,9 +37,7 @@ int lastLidarRun = 0;
 int lastErrRun = 0;
 int lastTimeRun = 288;
 
-
 WiFiClient client;
-int maxBuffer = 8192;
 int bufferSize = 0;
 uint8_t currentClient = 0;
 uint8_t serialBuffer[8193];
@@ -69,7 +70,7 @@ void getPage() {
       }
       if (batteryInfo != "" && batteryInfo != "-FAIL-" && serialNumber != "Empty") {
         HTTPClient http;  //Declare an object of class HTTPClient
-        http.begin("http://www.neatoscheduler.com/api/actionPull.php?serial="+serialNumber+"&battery="+batteryInfo+"&firmware="+firmware+"&errorMsg="+incomingErr);  //Specify request destination
+        http.begin("http://www.neatoscheduler.com/api/actionPull.php?serial="+serialNumber+"&battery="+batteryInfo+"&firmware="+FIRMWARE+"&errorMsg="+incomingErr);  //Specify request destination
         int httpCode = http.GET(); //Send the request
      
         if (httpCode > 0) { //Check the returning code
@@ -353,11 +354,11 @@ void serialEvent() {
     }
     serialBuffer[bufferSize] = in;
     bufferSize++;
-    // fill up the serial buffer until its max size (8192 bytes, see maxBuffer)
+    // fill up the serial buffer until its max size (8192 bytes, see MAX_BUFFER)
     // or unitl the end of file marker (ctrl-z; \x1A) is reached
-    // a worst caste lidar result should be just under 8k, so that maxBuffer
+    // a worst caste lidar result should be just under 8k, so that MAX_BUFFER
     // limit should not be reached under normal conditions
-    if (bufferSize > maxBuffer - 1 || in == '\x1A') {
+    if (bufferSize > MAX_BUFFER - 1 || in == '\x1A') {
       serialBuffer[bufferSize] = '\0';
       bool allSend = false;
       uint8_t localBuffer[1464];

--- a/botvac-wifi.ino
+++ b/botvac-wifi.ino
@@ -23,9 +23,12 @@
 
 #define AP_SSID "neato"
 
+#define FIRMWARE "1.7"
+
+#define MAX_BUFFER 8192
+
 String readString;
 String incomingErr;
-String firmware = "1.7";
 String batteryInfo;
 String lidarInfo;
 String serialNumber = "Empty";
@@ -34,9 +37,7 @@ int lastLidarRun = 0;
 int lastErrRun = 0;
 int lastTimeRun = 288;
 
-
 WiFiClient client;
-int maxBuffer = 8192;
 int bufferSize = 0;
 uint8_t currentClient = 0;
 uint8_t serialBuffer[8193];
@@ -69,7 +70,7 @@ void getPage() {
       }
       if (batteryInfo != "" && batteryInfo != "-FAIL-" && serialNumber != "Empty") {
         HTTPClient http;  //Declare an object of class HTTPClient
-        http.begin("http://www.neatoscheduler.com/api/actionPull.php?serial="+serialNumber+"&battery="+batteryInfo+"&firmware="+firmware+"&errorMsg="+incomingErr);  //Specify request destination
+        http.begin("http://www.neatoscheduler.com/api/actionPull.php?serial="+serialNumber+"&battery="+batteryInfo+"&firmware="+FIRMWARE+"&errorMsg="+incomingErr);  //Specify request destination
         int httpCode = http.GET(); //Send the request
      
         if (httpCode > 0) { //Check the returning code
@@ -353,11 +354,11 @@ void serialEvent() {
     }
     serialBuffer[bufferSize] = in;
     bufferSize++;
-    // fill up the serial buffer until its max size (8192 bytes, see maxBuffer)
+    // fill up the serial buffer until its max size (8192 bytes, see MAX_BUFFER)
     // or unitl the end of file marker (ctrl-z; \x1A) is reached
-    // a worst caste lidar result should be just under 8k, so that maxBuffer
+    // a worst caste lidar result should be just under 8k, so that MAX_BUFFER
     // limit should not be reached under normal conditions
-    if (bufferSize > maxBuffer - 1 || in == '\x1A') {
+    if (bufferSize > MAX_BUFFER - 1 || in == '\x1A') {
       serialBuffer[bufferSize] = '\0';
       bool allSend = false;
       uint8_t localBuffer[1464];

--- a/botvac-wifi.ino
+++ b/botvac-wifi.ino
@@ -20,10 +20,11 @@
 #define CONNECT_TIMEOUT_SECS 30
 
 #define AP_SSID "neato"
+
 String readString;
 String incomingSerial = "Empty";
 String incomingErr;
-String firmware = "1.6";
+String firmware = "1.7";
 String batteryInfo;
 String lidarInfo;
 int lastBattRun = 0;
@@ -367,18 +368,18 @@ void setup() {
     WiFi.disconnect();
     WiFi.mode(WIFI_STA);
     WiFi.begin(ssid, passwd);
-    
     for(int i = 0; i < CONNECT_TIMEOUT_SECS * 20 && WiFi.status() != WL_CONNECTED; i++) {
       delay(50);
     }
   }
 
   //start AP mode if either the AP / password do not exist, or cannot be connected to within CONNECT_TIMEOUT_SECS seconds.
-  if(WiFi.status() == WL_NO_SSID_AVAIL || WiFi.status() == WL_CONNECT_FAILED) {
+  if(WiFi.status() != WL_CONNECTED) {
     WiFi.disconnect();
     WiFi.mode(WIFI_AP);
-    if(! WiFi.softAP(AP_SSID))
+    if(! WiFi.softAP(AP_SSID)) {
       ESP.reset(); //reset because there's no good reason for setting up an AP to fail
+    }
   }
 
   // start websocket
@@ -422,7 +423,6 @@ void setup() {
   // start MDNS
   // this means that the botvac can be reached at http://neato.local or ws://neato.local:81
   if (!MDNS.begin("neato")) {
-    Serial.print('ieeee! MDNS failure!');
     ESP.reset(); //reset because there's no good reason for setting up MDNS to fail
   }
   MDNS.addService("http", "tcp", 80);

--- a/botvac-wifi.ino
+++ b/botvac-wifi.ino
@@ -265,6 +265,7 @@ void setupEvent() {
   "<input type=\"submit\" value=\"Submit\"> </form>" +
   "<p>Enter the details for your access point. After you submit, the controller will reboot to apply the settings.</p>" +
   "<p><a href=\"http://neato.local:82/update\">Update Firmware</a></p>" +
+  "<p><a href=\"http://neato.local/console\">Neato Serial Console</a> - <a href=\"https://www.neatorobotics.com/resources/programmersmanual_20140305.pdf\">Command Documentation</a></p>" +
   "</body></html>\n");
 }
 


### PR DESCRIPTION
This PR adds some fallback behavior for connecting to wifi, and adds some additional links and information in the root page. If connecting to an access point fails, the module will now return to AP mode so you can correct your settings. The current setting s are now also displayed in the form, so you can see if you made a typo.

Additionally, the submit button will now return a page to the browser instead of letting it hang, telling the user if changes were saved successfully or not.

Links are now provided to the firmware upload page, the console,a module reboot function, and the console documentation.

The serial number is now retrieved first thing, and is displayed in the page for ease of access.